### PR TITLE
Feat/column

### DIFF
--- a/src/main/generated/com/example/demo/domain/board/entity/QBoard.java
+++ b/src/main/generated/com/example/demo/domain/board/entity/QBoard.java
@@ -1,0 +1,41 @@
+package com.example.demo.domain.board.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBoard is a Querydsl query type for Board
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoard extends EntityPathBase<Board> {
+
+    private static final long serialVersionUID = -340161997L;
+
+    public static final QBoard board = new QBoard("board");
+
+    public final StringPath boardName = createString("boardName");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath intro = createString("intro");
+
+    public QBoard(String variable) {
+        super(Board.class, forVariable(variable));
+    }
+
+    public QBoard(Path<? extends Board> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBoard(PathMetadata metadata) {
+        super(Board.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/demo/domain/card/entity/QCard.java
+++ b/src/main/generated/com/example/demo/domain/card/entity/QCard.java
@@ -1,0 +1,47 @@
+package com.example.demo.domain.card.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCard is a Querydsl query type for Card
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCard extends EntityPathBase<Card> {
+
+    private static final long serialVersionUID = 1038004141L;
+
+    public static final QCard card = new QCard("card");
+
+    public final StringPath content = createString("content");
+
+    public final StringPath deadline = createString("deadline");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath status = createString("status");
+
+    public final StringPath title = createString("title");
+
+    public final StringPath worker = createString("worker");
+
+    public QCard(String variable) {
+        super(Card.class, forVariable(variable));
+    }
+
+    public QCard(Path<? extends Card> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCard(PathMetadata metadata) {
+        super(Card.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/demo/domain/column/entity/QBoardColumn.java
+++ b/src/main/generated/com/example/demo/domain/column/entity/QBoardColumn.java
@@ -1,0 +1,41 @@
+package com.example.demo.domain.column.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBoardColumn is a Querydsl query type for BoardColumn
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoardColumn extends EntityPathBase<BoardColumn> {
+
+    private static final long serialVersionUID = -1251865447L;
+
+    public static final QBoardColumn boardColumn = new QBoardColumn("boardColumn");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final NumberPath<Long> order = createNumber("order", Long.class);
+
+    public QBoardColumn(String variable) {
+        super(BoardColumn.class, forVariable(variable));
+    }
+
+    public QBoardColumn(Path<? extends BoardColumn> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBoardColumn(PathMetadata metadata) {
+        super(BoardColumn.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/example/demo/domain/permission/entity/QPermission.java
+++ b/src/main/generated/com/example/demo/domain/permission/entity/QPermission.java
@@ -1,0 +1,53 @@
+package com.example.demo.domain.permission.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPermission is a Querydsl query type for Permission
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPermission extends EntityPathBase<Permission> {
+
+    private static final long serialVersionUID = -1152457301L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPermission permission = new QPermission("permission");
+
+    public final EnumPath<PermissionType> authority = createEnum("authority", PermissionType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.example.demo.domain.user.entity.QUser user;
+
+    public QPermission(String variable) {
+        this(Permission.class, forVariable(variable), INITS);
+    }
+
+    public QPermission(Path<? extends Permission> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPermission(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPermission(PathMetadata metadata, PathInits inits) {
+        this(Permission.class, metadata, inits);
+    }
+
+    public QPermission(Class<? extends Permission> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.example.demo.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/demo/domain/user/entity/QUser.java
+++ b/src/main/generated/com/example/demo/domain/user/entity/QUser.java
@@ -1,0 +1,57 @@
+package com.example.demo.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -25341789L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath password = createString("password");
+
+    public final com.example.demo.domain.permission.entity.QPermission permission;
+
+    public final StringPath refreshToken = createString("refreshToken");
+
+    public final StringPath username = createString("username");
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.permission = inits.isInitialized("permission") ? new com.example.demo.domain.permission.entity.QPermission(forProperty("permission"), inits.get("permission")) : null;
+    }
+
+}
+

--- a/src/main/java/com/example/demo/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     COLUMN_ALREADY_DELETED_OR_NOT_EXIST(HttpStatus.NOT_FOUND, "이미 삭제된 컬럼이거나 존재하지 않는 컬럼입니다."),
     DUPLICATE_COLUMN_NAME(HttpStatus.CONFLICT, "이미 존재하는 컬럼 이름입니다."),
     DUPLICATE_STATUS_NAME(HttpStatus.CONFLICT, "이미 존재하는 상태 이름입니다."),
+    ORDER_MUST_BE_POSITIVE(HttpStatus.BAD_REQUEST, "순서는 양수여야 합니다."),
 
     // 소셜 로그인 도메인 오류 코드
     SOCIAL_TOKEN_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 소셜 유저 토큰을 가져오는데 실패했습니다."),

--- a/src/main/java/com/example/demo/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorCode.java
@@ -25,6 +25,19 @@ public enum ErrorCode {
     RECENT_PASSWORD_MATCH(HttpStatus.BAD_REQUEST, "최근 사용했던 비밀번호는 변경할 수 없습니다."),
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "입력하신 비밀번호가 일치하지 않습니다."),
 
+    // 사용자 권한 관련 오류 코드
+    USER_NOT_MANAGER(HttpStatus.CONFLICT, "해당 기능에 접근할 수 있는 권한이 없습니다."),
+
+    // 컬럼
+    STATUS_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "상태 이름은 필수 데이터입니다."),
+    BOARD_COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 보드에 존재하지 않는 컬럼입니다."),
+    COLUMN_IDS_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 컬럼 ID 목록입니다."),
+    COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "컬럼을 찾을 수 없습니다."),
+    COLUMN_ALREADY_DELETED_OR_NOT_EXIST(HttpStatus.NOT_FOUND, "이미 삭제된 컬럼이거나 존재하지 않는 컬럼입니다."),
+    DUPLICATE_COLUMN_NAME(HttpStatus.CONFLICT, "이미 존재하는 컬럼 이름입니다."),
+    DUPLICATE_STATUS_NAME(HttpStatus.CONFLICT, "이미 존재하는 상태 이름입니다."),
+
+
     // 소셜 로그인 도메인 오류 코드
     SOCIAL_TOKEN_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 소셜 유저 토큰을 가져오는데 실패했습니다."),
     SOCIAL_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 소셜 유저 데이터를 가져오는데 실패했습니다."),

--- a/src/main/java/com/example/demo/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorCode.java
@@ -37,10 +37,6 @@ public enum ErrorCode {
     DUPLICATE_COLUMN_NAME(HttpStatus.CONFLICT, "이미 존재하는 컬럼 이름입니다."),
     DUPLICATE_STATUS_NAME(HttpStatus.CONFLICT, "이미 존재하는 상태 이름입니다."),
 
-
-    // 사용자 권한 관련 오류 코드
-    USER_NOT_MANAGER(HttpStatus.CONFLICT, "해당 기능에 접근할 수 있는 권한이 없습니다."),
-
     // 소셜 로그인 도메인 오류 코드
     SOCIAL_TOKEN_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해당하는 소셜 유저 토큰을 가져오는데 실패했습니다."),
     SOCIAL_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 소셜 유저 데이터를 가져오는데 실패했습니다."),

--- a/src/main/java/com/example/demo/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/demo/domain/board/service/BoardService.java
@@ -58,4 +58,12 @@ public class BoardService {
 //        User invitedUser = userService.findUser(invitedUsername); //초대 할 사용자
 
     }
+
+
+    // 주어진 baordId로 Board 객체를 조회 (특정 보드 조회)
+    // 존재하지 않는 경우 예외처리
+    public Board findByBoardId(Long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 보드를 찾을 수 없습니다: " + boardId));
+    }
 }

--- a/src/main/java/com/example/demo/domain/column/controller/ColumnController.java
+++ b/src/main/java/com/example/demo/domain/column/controller/ColumnController.java
@@ -22,24 +22,35 @@ public class ColumnController {
 
 
     // 컬럼 생성 (보드에 컬럼 생성)
-    @PostMapping("/{id}/col")
-    public ResponseEntity<ResponseColumnDto> createColumn(@Valid @RequestBody RequestColumnDto requestColumnDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    @PostMapping("/{board_id}/col")
+    public ResponseEntity<ResponseColumnDto> createColumn(@Valid @PathVariable Long board_id,
+                                                          @RequestBody RequestColumnDto requestColumnDto,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 컬럼을 생성하는 서비스 메서드 호출
-        ResponseColumnDto createdColumn = columnService.createColumn(requestColumnDto, userDetails.getUser());
+        ResponseColumnDto createdColumn = columnService.createColumn(board_id, requestColumnDto, userDetails.getUser());
         return new ResponseEntity<>(createdColumn, HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/{id}/col/{id}")
-    public ResponseEntity<String> deleteColumn(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    // 컬럼 삭제
+    @DeleteMapping("/{board_id}/col/{col_id}")
+    public ResponseEntity<String> deleteColumn(@PathVariable Long board_id,
+                                               @PathVariable Long col_id,
+                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        columnService.deleteColumn(id, userDetails.getUser());
+        columnService.deleteColumn(board_id, col_id, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body("컬럼이 삭제되었습니다.");
     }
 
-    @PutMapping("/reorder")
-    public ResponseEntity<List<ResponseColumnDto>> reorderColumns(@RequestBody List<Long> columnIds, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        List<ResponseColumnDto> reorderedColumns = columnService.reorderColumns(columnIds, userDetails.getUser());
+    // 컬럼 순서 이동
+    // "확정" 버튼을 눌렀을 때 동작
+    // 보드 ID와 새로운 컬럼 순서(List<Long> columnIds)를 받음.
+    @PutMapping("/{board_id}/reorder")
+    public ResponseEntity<List<ResponseColumnDto>> reorderColumns(@PathVariable Long board_id,
+                                                                  @RequestBody List<Long> columnIds,
+                                                                  @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        List<ResponseColumnDto> reorderedColumns = columnService.reorderColumns(board_id, columnIds, userDetails.getUser());
         return new ResponseEntity<>(reorderedColumns, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/domain/column/entity/BoardColumn.java
+++ b/src/main/java/com/example/demo/domain/column/entity/BoardColumn.java
@@ -1,8 +1,12 @@
 package com.example.demo.domain.column.entity;
 
+import com.example.demo.domain.board.entity.Board;
+import com.example.demo.domain.card.entity.Card;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Table(name = "columns")
@@ -22,10 +26,20 @@ public class BoardColumn {
     @Column(nullable = false)
     private Long order; // 컬럼의 순서
 
+    // Board(1) : Column(N)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    // Column(1) : Card(N)
+    @OneToMany(mappedBy = "boardcolumn", cascade = CascadeType.ALL)
+    private List<Card> cards;
+
     // 생성자 추가
-    public BoardColumn(String name, Long order) {
+    public BoardColumn(String name, Long order, Board board) {
         this.name = name;
         this.order = order;
+        this.board = board;
     }
 
     // 순서 변경 메서드
@@ -35,12 +49,4 @@ public class BoardColumn {
         }
         this.order = newOrder;
     }
-
-    // 📢 임시 엔티티 관계 설정
-//    @ManyToOne
-//    @JoinColumn(name = "board_id")
-//    private Board board;
-//
-//    @OneToMany(mappedBy = "boardcolumn", cascade = CascadeType.ALL)
-//    private List<Card> cards;
 }

--- a/src/main/java/com/example/demo/domain/column/entity/BoardColumn.java
+++ b/src/main/java/com/example/demo/domain/column/entity/BoardColumn.java
@@ -1,5 +1,7 @@
 package com.example.demo.domain.column.entity;
 
+import com.example.demo.common.exception.CustomException;
+import com.example.demo.common.exception.ErrorCode;
 import com.example.demo.domain.board.entity.Board;
 import com.example.demo.domain.card.entity.Card;
 import jakarta.persistence.*;
@@ -45,7 +47,7 @@ public class BoardColumn {
     // 순서 변경 메서드
     public void changeOrder(Long newOrder) {
         if (newOrder == null || newOrder < 1) {
-            throw new IllegalArgumentException("Order must be a positive number");
+            throw new CustomException(ErrorCode.ORDER_MUST_BE_POSITIVE);
         }
         this.order = newOrder;
     }

--- a/src/main/java/com/example/demo/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/com/example/demo/domain/column/repository/ColumnRepository.java
@@ -1,9 +1,12 @@
 package com.example.demo.domain.column.repository;
 
+import com.example.demo.domain.board.entity.Board;
 import com.example.demo.domain.column.entity.BoardColumn;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -11,9 +14,19 @@ import java.util.Optional;
 // BoardColumn 엔티티에 대한 DB 엑세스, CRUD, 커스텀 쿼리(EX.findByName) 지원
 public interface ColumnRepository extends JpaRepository<BoardColumn, Long> {
 
-    boolean existsByName(String name); // 이미 존재하는 '상태 이름' 을 확인하기 위한 메서드
+    // 특정 보드의 특정 컬럼을 조회
+    Optional<Object> findByIdAndBoard(Long columnId, Board board);
 
-    // ColumnService 클래스에서 현재 최대 순서 값을 조회한 후 1을 더하는 방법을 사용하기 위해 메소드 추가
-    @Query("SELECT MAX(c.order) FROM BoardColumn c") // BoardColumn 엔티티의 order 속성 값 중 최대 값 선택
-    Optional<Long> findMaxOrder(); // 결과가 없을 수도 있기에 Optional을 사용하여 안전하게 처리
+    // 특정 보드 내에서 컬림 이름의 중복을 확인하는 메서드
+    boolean existsByNameAndBoard(String name, Board board);
+
+
+    // 특정 보드 내에서 최대 순서 값을 찾음
+    // 새 컬럼 추가 시 사용할 메서드
+    @Query("SELECT MAX(c.order) FROM BoardColumn c WHERE c.board = :board")
+    Optional<Long> findMaxOrderByBoard(@Param("board") Board board);
+
+    // 특정 보드의 모든 컬럼을 순서대로 조회
+    @Query("SELECT c FROM BoardColumn c WHERE c.board = :board ORDER BY c.order")
+    List<BoardColumn> findAllByBoardOrderByOrder(@Param("board") Board board);
 }

--- a/src/main/java/com/example/demo/domain/column/service/ColumnService.java
+++ b/src/main/java/com/example/demo/domain/column/service/ColumnService.java
@@ -1,5 +1,9 @@
 package com.example.demo.domain.column.service;
 
+import com.example.demo.common.exception.CustomException;
+import com.example.demo.common.exception.ErrorCode;
+import com.example.demo.domain.board.entity.Board;
+import com.example.demo.domain.board.service.BoardService;
 import com.example.demo.domain.column.dto.RequestColumnDto;
 import com.example.demo.domain.column.dto.ResponseColumnDto;
 import com.example.demo.domain.column.entity.BoardColumn;
@@ -10,9 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,32 +24,36 @@ public class ColumnService {
 
 
     private final ColumnRepository columnRepository;
+    private final BoardService boardService;
 
 
     // 컬럼 생성 (보드에 컬럼 생성)
     @Transactional
-    public ResponseColumnDto createColumn(RequestColumnDto requestDto, User user) {
+    public ResponseColumnDto createColumn(Long boardId, RequestColumnDto requestDto, User user) {
+        // 변경 후 : 보드 ID로 특정 Board 객체를 조회 => BoardColumn을 생성
+        Board board = boardService.findByBoardId(boardId);
+
         // 권한 체크: MANAGER 권한을 가진 사용자만 컬럼 생성 허용
         if (user.getPermission() != PermissionType.MANAGER) {
-            throw new IllegalArgumentException("컬럼 생성 권한이 없습니다. MANAGER 권한이 필요합니다.");
+            throw new CustomException(ErrorCode.USER_NOT_MANAGER);
         }
 
         // 상태 이름 필수 데이터 체크
         if (requestDto.getName() == null || requestDto.getName().trim().isEmpty()) {
-            throw new IllegalArgumentException("상태 이름은 필수 데이터입니다.");
+            throw new CustomException(ErrorCode.STATUS_NAME_NOT_FOUND);
         }
 
-        // 이미 존재하는 상태 이름 체크
-        if (columnRepository.existsByName(requestDto.getName())) {
-            throw new IllegalArgumentException("이미 존재하는 상태 이름입니다.");
+        // 이미 존재하는 상태 이름 체크 (보드 내에서 유일해야 함)
+        if (columnRepository.existsByNameAndBoard(requestDto.getName(), board)) {
+            throw new CustomException(ErrorCode.DUPLICATE_STATUS_NAME);
         }
 
-        // 새 컬럼의 순서 결정
-        Long maxOrder = columnRepository.findMaxOrder().orElse(0L);
+        // 새 컬럼의 순서 결정 (보드 내에서의 순서)
+        Long maxOrder = columnRepository.findMaxOrderByBoard(board).orElse(0L);
         Long newOrder = maxOrder + 1;
 
         // BoardColumn 객체 생성
-        BoardColumn boardColumn = new BoardColumn(requestDto.getName(), newOrder);
+        BoardColumn boardColumn = new BoardColumn(requestDto.getName(), newOrder, board);
 
         // 저장 및 반환
         boardColumn = columnRepository.save(boardColumn);
@@ -54,53 +61,94 @@ public class ColumnService {
     }
 
 
+
     // 컬럼 삭제
-    // 삭제할 때 ‘삭제하는 경우 연결된 데이터가 전부 삭제됩니다. 정말 삭제하시겠습니까?’ => 프론트에서 처리
-    // 취소 → 삭제 기능 수행 X
-    // 확인 → 삭제 기능 수행
+    // ✅ 삭제할 때 ‘삭제하는 경우 연결된 데이터가 전부 삭제됩니다. 정말 삭제하시겠습니까?’ => 프론트에서 처리
     @Transactional
-    public void deleteColumn(Long id, User user) {
-        // MANAGER 권한 체크
+    public void deleteColumn(Long boardId, Long columnId, User user) {
+        // 변경 후 : 보드 ID와 컬럼 ID를 모두 사용하여 해당 보드에 속한 컬럼만을 삭제
+        // 특정 보드에 특정 컬럼만 삭제하여 다른 보드의 컬럼을 삭제하는 것을 방지
+        Board board = boardService.findByBoardId(boardId);
+
         if (user.getPermission() != PermissionType.MANAGER) {
-            throw new IllegalArgumentException("컬럼 삭제 권한이 없습니다. MANAGER 권한이 필요합니다.");
+            throw new CustomException(ErrorCode.USER_NOT_MANAGER);
         }
-        BoardColumn boardColumn = columnRepository.findById(id)
-                // 예외 처리 : 중복 '상태 이름'
-                .orElseThrow(() -> new IllegalArgumentException("이미 삭제된 컬럼이거나 존재하지 않는 컬럼입니다."));
+
+        BoardColumn boardColumn = (BoardColumn) columnRepository.findByIdAndBoard(columnId, board)
+                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_ALREADY_DELETED_OR_NOT_EXIST));
+
         columnRepository.delete(boardColumn);
     }
 
 
-    // 컬럼 순서 이동
+    // 컬럼 순서 이동 (실제 순서 변경하는 로직)
     // 성공 조건 :
     // (1). 자유로운 순서 변경 : reorderColumns 메소드로 구현
     // (2). 새로고침 후 유지 : DB에 저장되므로 구현
-    // 현재 순서 이동 방식은 '확정' 버튼을 누르는 방식에 가까움, 드래그 앤 드롭 시 마다 순서를 변경하려면
-    // 프론트엔드에서 각 이동마다 API를 호출하도록 구현
+
+    // 현재 순서 이동 방식은 '확정' 버튼을 누르는 방식에 가까움,
+    // ➡️드래그 앤 드롭 시 마다 순서를 변경하려면 프론트엔드에서 각 이동마다 API를 호출하도록 구현
+
+
+
+    /*
+    📢 드래그 앤 드롭 프로세스 :
+    (1). 사용자가 드래그 앤 드롭으로 컬럼 순서를 변경 => 프론트엔드에서 처리
+    (2). 사용자가 '확정' 버튼을 클릭시, 프론트엔드는 새로운컬럼 순서(columnIds)를 백엔드 API(/{board_id}/reorder)로 전송
+    (3). 컨트롤러는 요청을 받아서 ColumnService에 reorderColumns 메소드를 호출
+    (4). reorderColumns 메소드는
+
+            - 사용자 권한 확인
+            - 보드 ID로 해당 보드의 모든 컬럼 조회
+            - 입력된 컬럼 ID리스트 유효성 검사
+            - 각 컬럼의 순서를 새로운 순서에 맞게 UPDATE
+            - 변경된 컬럼들을 DB에 저장
+            - 업데이트된 컬럼 정보를 DTO로 변환하여 반환
+
+     (5). 컨트롤러는 업데이트된 컬럼 정보를 클라이언트에 반환
+     (6). 프론트엔드는 반환된 정보로 UI를 업뎃
+     (7). 사용자가 페이지를 새로고침해도 DB에 저장된 새로운 순서대로 컬럼이 표시
+            => findAllByBoardOrderByOrder 메서드가 컬럼을 순서대로 조회하기 때문
+
+
+     📢 기대효과
+
+            - 컬럼 순서 자유롭게 변경 가능
+            - 새로고침 후에도 변경된 순서 유지
+            - '확정' 버튼(백엔드 API reorder) 을 통해 순서 변경을 적용
+     */
+
+    // 변경 전 : 모든 보드의 컬럼을 대상으로 재정렬
+    // 변경 후 : 특정 보드의 컬람만을 대상으로 재정렬
+    // => 특정 보드 내에서만 컬럼 순서를 변경하기 때문에 다른 보드의 컬럼 순서에 영향 X
     @Transactional
-    public List<ResponseColumnDto> reorderColumns(List<Long> columnIds, User user) {
-        // MANAGER 권한 체크
+    public List<ResponseColumnDto> reorderColumns(Long boardId, List<Long> columnIds, User user) {
+
+        // 권한 체크
         if (user.getPermission() != PermissionType.MANAGER) {
-            throw new IllegalArgumentException("컬럼 순서 변경 권한이 없습니다. MANAGER 권한이 필요합니다.");
+            throw new CustomException(ErrorCode.USER_NOT_MANAGER);
         }
 
-        List<BoardColumn> boardColumns = columnRepository.findAllById(columnIds);
-        // Map을 사용하여 각 ID에 대한 BoardColumn을 빠르게 get
-        Map<Long, BoardColumn> columnMap = boardColumns.stream()
-                .collect(Collectors.toMap(BoardColumn::getId, Function.identity()));
+        Board board = boardService.findByBoardId(boardId);
+        List<BoardColumn> boardColumns = columnRepository.findAllByBoardOrderByOrder(board);
+
+        // 입력된 컬럼 ID들의 유효성을 검사
+        if (boardColumns.size() != columnIds.size() || !boardColumns.stream().map(BoardColumn::getId).collect(Collectors.toSet()).equals(new HashSet<>(columnIds))) {
+            throw new CustomException(ErrorCode.COLUMN_IDS_NOT_VALID);
+        }
 
         // 순서 재정렬 로직
-        // 각 열의 order 속성 update
         for (int i = 0; i < columnIds.size(); i++) {
             Long id = columnIds.get(i);
-            BoardColumn boardColumn = columnMap.get(id);
-            if (boardColumn == null) {
-                throw new IllegalArgumentException("컬럼을 찾을 수 없습니다: " + id);
-            }
-            boardColumn.changeOrder(Long.valueOf(i + 1)); // 순서 재정렬
+            BoardColumn boardColumn = boardColumns.stream()
+                    .filter(col -> col.getId().equals(id))
+                    .findFirst()
+                    // 찾을 수 없는 id 값을 나타내기 위해 임식적으로 IllegalArgumentException 처리
+                    .orElseThrow(() -> new IllegalArgumentException("컬럼을 찾을 수 없습니다: " + id));
+            boardColumn.changeOrder((long) (i + 1));
         }
 
-        // 열 저장 및 반환
+        // 변경된 컬럼들을 저장하고 DTO로 변환하여 반환
         boardColumns = columnRepository.saveAll(boardColumns);
         return boardColumns.stream().map(this::convertToResponseDto).collect(Collectors.toList());
     }

--- a/src/main/java/com/example/demo/domain/column/service/ColumnService.java
+++ b/src/main/java/com/example/demo/domain/column/service/ColumnService.java
@@ -4,6 +4,7 @@ import com.example.demo.domain.column.dto.RequestColumnDto;
 import com.example.demo.domain.column.dto.ResponseColumnDto;
 import com.example.demo.domain.column.entity.BoardColumn;
 import com.example.demo.domain.column.repository.ColumnRepository;
+import com.example.demo.domain.permission.entity.PermissionType;
 import com.example.demo.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class ColumnService {
     @Transactional
     public ResponseColumnDto createColumn(RequestColumnDto requestDto, User user) {
         // 권한 체크: MANAGER 권한을 가진 사용자만 컬럼 생성 허용
-        if (!"MANAGER".equals(user.getPermission().getAuthority().getAuthority())) {
+        if (user.getPermission() != PermissionType.MANAGER) {
             throw new IllegalArgumentException("컬럼 생성 권한이 없습니다. MANAGER 권한이 필요합니다.");
         }
 
@@ -60,7 +61,7 @@ public class ColumnService {
     @Transactional
     public void deleteColumn(Long id, User user) {
         // MANAGER 권한 체크
-        if (!"MANAGER".equals(user.getPermission().getAuthority().getAuthority())) {
+        if (user.getPermission() != PermissionType.MANAGER) {
             throw new IllegalArgumentException("컬럼 삭제 권한이 없습니다. MANAGER 권한이 필요합니다.");
         }
         BoardColumn boardColumn = columnRepository.findById(id)
@@ -79,7 +80,7 @@ public class ColumnService {
     @Transactional
     public List<ResponseColumnDto> reorderColumns(List<Long> columnIds, User user) {
         // MANAGER 권한 체크
-        if (!"MANAGER".equals(user.getPermission().getAuthority().getAuthority())) {
+        if (user.getPermission() != PermissionType.MANAGER) {
             throw new IllegalArgumentException("컬럼 순서 변경 권한이 없습니다. MANAGER 권한이 필요합니다.");
         }
 

--- a/src/main/java/com/example/demo/domain/user/entity/User.java
+++ b/src/main/java/com/example/demo/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.user.entity;
 
 import com.example.demo.domain.permission.entity.Permission;
+import com.example.demo.domain.permission.entity.PermissionType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,8 +27,8 @@ public class User {
     @Column
     private String refreshToken;
 
-    @Getter
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    // User(1) : Permission(N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Permission> permissions = new ArrayList<>();
 
     @Builder
@@ -37,4 +38,20 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
+    // 사용자의 권한을 반환하는 역할
+    public PermissionType getPermission() {
+        // permissions 가 null 이거나 리스타가 비어 있는 경우 USER 권한 반환
+        // null => 리스트가 초기화되지 않았거나 객체가 할당되지 않은 상태를 체크
+        // isEmpty() => permissions 리스트가 초기화되었지만 요소가 포함되지 않은 상태를 체크
+        if (permissions == null || permissions.isEmpty()) {
+            return PermissionType.USER; // 기본 권한
+        }
+
+        // MANAGER 권한이 있는지 확인
+        boolean hasManagerPermission = permissions.stream()
+                .anyMatch(permission -> PermissionType.MANAGER.equals(permission.getAuthority()));
+
+        // 사용자가 MANAGER 권한을 가질 시 MANAGER 반환, 아니면 USER 반환
+        return hasManagerPermission ? PermissionType.MANAGER : PermissionType.USER;
+    }
 }


### PR DESCRIPTION
## 📝작업 내용

### 지난 피드백 해결 및 기능 추가 

<br>

-  User 엔티티,  User(1) : Permission(N) 관계에 대한 명확한 정의 (일대다 관계) , 권한을 반환하는 역할인 getPermission() 메서드 추가

<br>

- User  엔티티에 getPermission() 메서드가 직접 PermissionType을 반환하도록 변경하여 권한 비교를 더 직관적으로 개선

`if (user.getPermission() != PermissionType.MANAGER) {`

- ColumnService 업데이트 



   (1). '변경 후' 로 주석에 명시하여 기능의 변경을 요약

   (2). 특정 보드를 가져오기 위해BoardService 필드 선언 & 관련 클래스 import

   (3). 기존 Exception 을CustomException 으로 처리

```
// 컬럼
    STATUS_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "상태 이름은 필수 데이터입니다."),
    BOARD_COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 보드에 존재하지 않는 컬럼입니다."),
    COLUMN_IDS_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 컬럼 ID 목록입니다."),
    COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "컬럼을 찾을 수 없습니다."),
    COLUMN_ALREADY_DELETED_OR_NOT_EXIST(HttpStatus.NOT_FOUND, "이미 삭제된 컬럼이거나 존재하지 않는 컬럼입니다."),
    DUPLICATE_COLUMN_NAME(HttpStatus.CONFLICT, "이미 존재하는 컬럼 이름입니다."),
    DUPLICATE_STATUS_NAME(HttpStatus.CONFLICT, "이미 존재하는 상태 이름입니다."),
```
   
      (4). 타 클래스에서 새로 생긴 메서드나 기존 메서드의 이름이 바뀜에 따라 추가 및 변경

      (5). 컬럼 순서 이동에 대한 프로세스 정리 (개인적으로 궁금해서)

      (6). 순서 이동 로직 Map 삭제,HashSet 사용


<br>
<br>

- ColumnRepository 업데이트 


```
    // 특정 보드의 특정 컬럼을 조회
    Optional<Object> findByIdAndBoard(Long columnId, Board board);

    // 특정 보드 내에서 컬림 이름의 중복을 확인하는 메서드
    boolean existsByNameAndBoard(String name, Board board);


    // 특정 보드 내에서 최대 순서 값을 찾음
    // 새 컬럼 추가 시 사용할 메서드
    @Query("SELECT MAX(c.order) FROM BoardColumn c WHERE c.board = :board")
    Optional<Long> findMaxOrderByBoard(@Param("board") Board board);

    // 특정 보드의 모든 컬럼을 순서대로 조회
    @Query("SELECT c FROM BoardColumn c WHERE c.board = :board ORDER BY c.order")
    List<BoardColumn> findAllByBoardOrderByOrder(@Param("board") Board board);

```

<br>

- ColumnController 특정 보드 찾기 위해서 board_id 추가 & API 명확하게 수정

![image](https://github.com/user-attachments/assets/ae974bd1-0f29-4ebc-a92b-7ff41230da68)

<br>

- BoardColumn 엔티티에 Board와 Card 엔티티 관계 설정 

<br>

- BoardService 에 주어진 baordId로 Board 객체를 조회 (특정 보드 조회) 하는 메서드 findByBoardId 생성

<br>

- Query Dsl Class Update

<br><br>

## 🔎 의문점 


- Query Dsl에 개념이 잡혀있지 않아서 병합하는 과정에서 column 브랜치에 있는 QPermission, QUser 클래스를 병합하였는데
  기존에서 바뀐 부분은 아래와 같습니다! 


(1). QPermission

 ```
public QPermission(String variable) {
        this(Permission.class, forVariable(variable), INITS);
    }

    public QPermission(Path<? extends Permission> path) {
        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
    }

    public QPermission(PathMetadata metadata) {
        this(metadata, PathInits.getFor(metadata, INITS));
    }

    public QPermission(PathMetadata metadata, PathInits inits) {
        this(Permission.class, metadata, inits);
    }

    public QPermission(Class<? extends Permission> type, PathMetadata metadata, PathInits inits) {
        super(type, metadata, inits);
        this.user = inits.isInitialized("user") ? new com.example.demo.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
    }
```

(2). QUser 

```
public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
        super(type, metadata, inits);
        this.permission = inits.isInitialized("permission") ? new com.example.demo.domain.permission.entity.QPermission(forProperty("permission"), inits.get("permission")) : null;
    }
```

이와 같이 병합하였는데 문제가 없는지에 대해 피드백 주시면 감사하겠습니다!


<br><br>

- Exception 처리 


```
// 순서 재정렬 로직
        for (int i = 0; i < columnIds.size(); i++) {
            Long id = columnIds.get(i);
            BoardColumn boardColumn = boardColumns.stream()
                    .filter(col -> col.getId().equals(id))
                    .findFirst()
                    // 찾을 수 없는 id 값을 나타내기 위해 임식적으로 IllegalArgumentException 처리
                    .orElseThrow(() -> new IllegalArgumentException("컬럼을 찾을 수 없습니다: " + id));
            boardColumn.changeOrder((long) (i + 1));
        }
```

이 부분과 

```
// 주어진 baordId로 Board 객체를 조회 (특정 보드 조회)
    // 존재하지 않는 경우 예외처리
    public Board findByBoardId(Long boardId) {
        return boardRepository.findById(boardId)
                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 보드를 찾을 수 없습니다: " + boardId));
    }
```

이 부분에서 Exception 처리를 id 값을 나타내기 위해서 IllegalArgumentException로 처리하였는데 ErroCode enum 을 수정하여 CustomException 처리로 id 값과 같이 나타나게 할지 아니면 그냥 IllegalArgumentException 처리로 할지 아니면 id 값을 지우고 CustomException로 처리할지 피드백 주시면 감사하겠습니다!

<br><br>

## 🔎 앞으로의 과제

- 카드 댓글 상세 기능

- 정상 작동 확인