### PR TITLE
Feat/column : 카드 상세 기능 구현 & 기존 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/common/exception/ErrorCode.java
@@ -54,6 +54,10 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_NOT_USER(HttpStatus.FORBIDDEN, "해당 댓글의 작성자가 아닙니다."),
     COMMENT_SAME_USER(HttpStatus.FORBIDDEN, "해당 댓글의 작성자입니다."),
+    USER_NOT_LOGGED_IN_TO_CREATE_COMMENT(HttpStatus.UNAUTHORIZED, "댓글을 작성하려면 로그인해야 합니다."),
+    CANNOT_COMMENT_ON_DELETED_CARD(HttpStatus.BAD_REQUEST, "삭제된 카드에는 댓글을 달 수 없습니다."),
+    USER_NOT_LOGGED_IN_TO_VIEW_COMMENTS(HttpStatus.UNAUTHORIZED, "댓글을 보려면 로그인해야 합니다."),
+    CANNOT_VIEW_COMMENTS_OF_DELETED_CARD(HttpStatus.BAD_REQUEST, "삭제된 카드의 댓글을 볼 수 없습니다."),
 
     // 팔로우 도메인 오류 코드
     SAME_USER(HttpStatus.BAD_REQUEST, "자신을 팔로우 할 수 없습니다."),

--- a/src/main/java/com/example/demo/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/demo/domain/board/repository/BoardRepository.java
@@ -1,6 +1,5 @@
 package com.example.demo.domain.board.repository;
 
-import com.example.demo.domain.board.dto.BoardResponseDto;
 import com.example.demo.domain.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/demo/domain/card/controller/CardController.java
+++ b/src/main/java/com/example/demo/domain/card/controller/CardController.java
@@ -1,13 +1,12 @@
 package com.example.demo.domain.card.controller;
 
-
-import com.example.demo.domain.board.service.BoardService;
 import com.example.demo.domain.card.dto.CardRequestDto;
 import com.example.demo.domain.card.dto.CardResponseDto;
 import com.example.demo.domain.card.service.CardService;
 import com.example.demo.domain.column.entity.BoardColumn;
 import com.example.demo.domain.column.service.ColumnService;
 import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +24,7 @@ public class CardController {
 
     private final CardService cardService;
     private final ColumnService columnService;
+    private final UserService userService;
 
     @GetMapping("/card")
     public ResponseEntity<List<CardResponseDto>> getCards() {
@@ -32,16 +32,20 @@ public class CardController {
     }
 
     @PostMapping("/card")
-    public ResponseEntity<CardResponseDto> createCard(@RequestBody @Valid CardRequestDto requestDto ,@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CardResponseDto> createCard(@RequestBody @Valid CardRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
         BoardColumn boardColumn = columnService.findStatus(requestDto.getStatus());
+        User user = userService.findUserByUsername(userDetails.getUsername());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(cardService.createCard(requestDto, userDetails.getUsername(), boardColumn));
+                .body(cardService.createCard(requestDto, userDetails.getUsername(), boardColumn, user));
     }
+
     @PutMapping("/card/{cardId}")
-    public ResponseEntity<CardResponseDto> updateCard(@PathVariable Long cardId,@RequestBody @Valid CardRequestDto requestDto ,@AuthenticationPrincipal UserDetails userDetails){
+    public ResponseEntity<CardResponseDto> updateCard(@PathVariable Long cardId, @RequestBody @Valid CardRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
+        User user = userService.findUserByUsername(userDetails.getUsername());
         return ResponseEntity.status(HttpStatus.OK)
-                .body(cardService.updateCard(cardId, requestDto, userDetails.getUsername()));
+                .body(cardService.updateCard(cardId, requestDto, userDetails.getUsername(), user));
     }
+
     @DeleteMapping("/card/{cardId}")
     public ResponseEntity<String> deleteCard(@PathVariable Long cardId) {
         cardService.deleteCard(cardId);

--- a/src/main/java/com/example/demo/domain/card/entity/Card.java
+++ b/src/main/java/com/example/demo/domain/card/entity/Card.java
@@ -2,14 +2,16 @@ package com.example.demo.domain.card.entity;
 
 import com.example.demo.domain.card.dto.CardRequestDto;
 import com.example.demo.domain.column.entity.BoardColumn;
+import com.example.demo.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Card{
+public class Card {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "card_id")
@@ -21,33 +23,45 @@ public class Card{
     @Column(name = "status", nullable = false)
     private String status;
 
-    @Column(name="content", nullable = true)
-    private  String content;
+    @Column(name = "content", nullable = true)
+    private String content;
 
-    @Column(name="deadline", nullable = true)
+    @Column(name = "deadline", nullable = true)
     private String deadline;
 
-    @Column(name="worker", nullable = true)
-    private  String worker;
+    @Column(name = "worker", nullable = true)
+    private String worker;
+
+    @Setter
+    @Getter
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
 
     @ManyToOne
     @JoinColumn(name = "boardcolumn_id", nullable = false)
     private BoardColumn boardColumn;
 
-    public Card(CardRequestDto requestDto, String username, BoardColumn boardColumn) {
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Card(CardRequestDto requestDto, String username, BoardColumn boardColumn, User user) {
         this.title = requestDto.getTitle();
         this.status = boardColumn.getName();
         this.content = requestDto.getContent();
         this.deadline = requestDto.getDeadline();
         this.worker = username;
         this.boardColumn = boardColumn;
+        this.user = user;
     }
-    public void update(CardRequestDto requestDto, String username, BoardColumn boardColumn ) {
+
+    public void update(CardRequestDto requestDto, String username, BoardColumn boardColumn, User user) {
         this.title = requestDto.getTitle();
         this.content = requestDto.getContent();
         this.deadline = requestDto.getDeadline();
         this.worker = username;
         this.boardColumn = boardColumn;
+        this.user = user;
     }
 
     public String getStatus(){

--- a/src/main/java/com/example/demo/domain/card/service/CardService.java
+++ b/src/main/java/com/example/demo/domain/card/service/CardService.java
@@ -3,50 +3,52 @@ package com.example.demo.domain.card.service;
 
 import com.example.demo.common.exception.CustomException;
 import com.example.demo.common.exception.ErrorCode;
-import com.example.demo.domain.board.service.BoardService;
 import com.example.demo.domain.card.dto.CardRequestDto;
 import com.example.demo.domain.card.dto.CardResponseDto;
 import com.example.demo.domain.card.entity.Card;
 import com.example.demo.domain.card.repository.CardRepository;
 import com.example.demo.domain.column.entity.BoardColumn;
+import com.example.demo.domain.permission.entity.Permission;
+import com.example.demo.domain.permission.entity.PermissionType;
+import com.example.demo.domain.permission.repository.PermissionRepository;
+import com.example.demo.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CardService {
 
     private final CardRepository cardRepository;
-    private final BoardService boardService;
+    private final PermissionRepository permissionRepository;
 
     public List<CardResponseDto> getCards() {
         List<CardResponseDto> result = new ArrayList<>();
-        List<String> statuses = List.of("todo", "in-progress", "done","emergency");  // 4종류 status 값을 넣어주세요
+        List<String> statuses = List.of("todo", "in-progress", "done", "emergency");  // 4종류 status 값을 넣어주세요
 
         for (String status : statuses) {
             List<Card> cards = cardRepository.findByStatus(status);
             result.addAll(cards.stream()
                     .map(CardResponseDto::new)
-                    .collect(Collectors.toList()));
+                    .toList());
         }
 
         return result;
     }
 
-    public CardResponseDto createCard(CardRequestDto requestDto, String username, BoardColumn boardColumn) {
-        Card card =cardRepository.save(new Card(requestDto ,username ,boardColumn));
+    public CardResponseDto createCard(CardRequestDto requestDto, String username, BoardColumn boardColumn, User user) {
+        Card card = cardRepository.save(new Card(requestDto, username, boardColumn, user));
         return new CardResponseDto(card);
     }
 
-    public CardResponseDto updateCard(Long cardId, CardRequestDto requestDto, String username) {
+    public CardResponseDto updateCard(Long cardId, CardRequestDto requestDto, String username, User user) {
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CARD_NOT_FOUND));
         BoardColumn boardColumn = new BoardColumn();
-        card.update(requestDto, username, boardColumn);
+        card.update(requestDto, username, boardColumn, user);
         cardRepository.save(card);
         return new CardResponseDto(card);
     }
@@ -61,5 +63,16 @@ public class CardService {
         return cardRepository.findById(cardId).orElseThrow(() -> new CustomException(ErrorCode.CARD_NOT_FOUND));
     }
 
-
+    public boolean hasPermissionForCard(Long userId, Long cardId) {
+        // 카드 조회 
+        Card card = cardRepository.findById(cardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CARD_NOT_FOUND));
+        // 보드 ID 추출
+        Long boardId = card.getBoardColumn().getBoard().getId();
+        // 사용자 권한 조회
+        Permission permission = permissionRepository.findByUser_IdAndBoard_Id(userId, boardId);
+       // 권한 검사 및 결과를 반환 (권한이 매니저이거나 카드를 생성한 사용자의 ID 인지)
+        return permission != null && (permission.getAuthority() == PermissionType.MANAGER
+                || card.getUser().getId().equals(userId));
+    }
 }

--- a/src/main/java/com/example/demo/domain/column/controller/ColumnController.java
+++ b/src/main/java/com/example/demo/domain/column/controller/ColumnController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/board")
+@RequestMapping("/api/board{boardId}")
 @RequiredArgsConstructor
 public class ColumnController {
 
@@ -22,22 +22,22 @@ public class ColumnController {
 
 
     // 컬럼 생성 (보드에 컬럼 생성)
-    @PostMapping("/{board_id}/col")
-    public ResponseEntity<ResponseColumnDto> createColumn(@Valid @PathVariable Long board_id,
+    @PostMapping("/col")
+    public ResponseEntity<ResponseColumnDto> createColumn(@Valid @PathVariable Long boardId,
                                                           @RequestBody RequestColumnDto requestColumnDto,
                                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 컬럼을 생성하는 서비스 메서드 호출
-        ResponseColumnDto createdColumn = columnService.createColumn(board_id, requestColumnDto, userDetails.getUser());
+        ResponseColumnDto createdColumn = columnService.createColumn(boardId, requestColumnDto, userDetails.getUser());
         return new ResponseEntity<>(createdColumn, HttpStatus.CREATED);
     }
 
     // 컬럼 삭제
-    @DeleteMapping("/{board_id}/col/{col_id}")
-    public ResponseEntity<String> deleteColumn(@PathVariable Long board_id,
-                                               @PathVariable Long col_id,
+    @DeleteMapping("/col/{colId}")
+    public ResponseEntity<String> deleteColumn(@PathVariable Long boardId,
+                                               @PathVariable Long colId,
                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        columnService.deleteColumn(board_id, col_id, userDetails.getUser());
+        columnService.deleteColumn(boardId, colId, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body("컬럼이 삭제되었습니다.");
     }
 
@@ -45,12 +45,12 @@ public class ColumnController {
     // 컬럼 순서 이동
     // "확정" 버튼을 눌렀을 때 동작
     // 보드 ID와 새로운 컬럼 순서(List<Long> columnIds)를 받음.
-    @PutMapping("/{board_id}/reorder")
-    public ResponseEntity<List<ResponseColumnDto>> reorderColumns(@PathVariable Long board_id,
+    @PutMapping("/reorder")
+    public ResponseEntity<List<ResponseColumnDto>> reorderColumns(@PathVariable Long boardId,
                                                                   @RequestBody List<Long> columnIds,
                                                                   @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        List<ResponseColumnDto> reorderedColumns = columnService.reorderColumns(board_id, columnIds, userDetails.getUser());
+        List<ResponseColumnDto> reorderedColumns = columnService.reorderColumns(boardId, columnIds, userDetails.getUser());
         return new ResponseEntity<>(reorderedColumns, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/demo/domain/column/dto/RequestColumnDto.java
+++ b/src/main/java/com/example/demo/domain/column/dto/RequestColumnDto.java
@@ -2,7 +2,6 @@ package com.example.demo.domain.column.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/example/demo/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/demo/domain/comment/controller/CommentController.java
@@ -1,0 +1,51 @@
+package com.example.demo.domain.comment.controller;
+
+import com.example.demo.domain.comment.dto.CommentRequestDto;
+import com.example.demo.domain.comment.dto.CommentResponseDto;
+import com.example.demo.domain.comment.service.CommentService;
+import com.example.demo.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    // 카드 댓글 생성
+    @PostMapping("/cards/{cardId}/comments")
+    public ResponseEntity<CommentResponseDto> createComment(@PathVariable Long cardId,
+                                                            @Valid @RequestBody CommentRequestDto requestDto,
+                                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 사용자의 정보가 null 이 아니면(르그인 O) username 에 userDetails 의 사용자 이름을 할당
+        // null 이면(로그인 X) username 에 null 을 할당
+        String username = userDetails != null ? userDetails.getUsername() : null;
+        CommentResponseDto createdComment = commentService.createComment(cardId, requestDto, username);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
+    }
+
+    // 초대 받은 모든 보드에서 생성된 카드의 댓글 조회
+    @GetMapping("/comments/invited")
+    public ResponseEntity<List<CommentResponseDto>> getAllCommentsFromInvitedBoards(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String username = userDetails != null ? userDetails.getUsername() : null;
+        List<CommentResponseDto> comments = commentService.getAllCommentsFromInvitedBoards(username);
+        return ResponseEntity.ok(comments);
+    }
+
+    // 특정 카드 댓글 조회
+    @GetMapping("/cards/{cardId}/comments")
+    public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable Long cardId,
+                                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String username = userDetails != null ? userDetails.getUsername() : null;
+        List<CommentResponseDto> comments = commentService.getCommentsByCardId(cardId, username);
+        return ResponseEntity.ok(comments);
+    }
+}

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentRequestDto.java
@@ -1,0 +1,33 @@
+package com.example.demo.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequestDto {
+    // 필수 데이터인 내용
+    @NotBlank(message = "댓글 내용이 필요합니다.")
+    @Size(min = 1, max = 255, message = "댓글 내용은 1자 이상 255자 이하여야 합니다.")
+    private String content;
+}
+
+
+// 클라이언트에서 요청을 보낼 때 사용할 수 있는 예시 (JSON 형태)
+/*
+{
+    "content": "comment"
+}
+*/
+
+// 응답 예시 (JSON 형태)
+/*
+{
+    "id": 1,
+    "content": "comment",
+    "createdAt": "2023-07-15 ~ ",
+    "username": "123"
+}
+*/

--- a/src/main/java/com/example/demo/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/demo/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.demo.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponseDto {
+    private Long id;
+    private String content;
+    private LocalDateTime createdAt;
+    private String username;
+}

--- a/src/main/java/com/example/demo/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/demo/domain/comment/entity/Comment.java
@@ -1,0 +1,46 @@
+package com.example.demo.domain.comment.entity;
+
+import com.example.demo.domain.card.entity.Card;
+import com.example.demo.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    // Comment(N) : Card(1)
+    // 댓글은 반드시 카드에 속해야 함을 의미
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card; // 댓글이 속한 카드
+
+    // Comment(N) : User(1)
+    // 댓글은 반드시 사용자에 속해야함을 의미
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 댓글을 작성한 사용자
+
+    // 생성자
+    public Comment(String content, Card card, User user) {
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.card = card;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/demo/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.example.demo.domain.comment.repository;
+
+import com.example.demo.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // 특정 카드 ID에 해당하는 댓글을 생성일지 기준으로 내침차순 정렬하여 반환
+    // findByCardId: cardId를 기준으로 댓글을 조회
+    // OrderByCreatedAtDesc: createdAt 필드를 기준으로 내림차순 정렬
+    List<Comment> findByCardIdOrderByCreatedAtDesc(Long cardId);
+}

--- a/src/main/java/com/example/demo/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/demo/domain/comment/service/CommentService.java
@@ -1,0 +1,131 @@
+package com.example.demo.domain.comment.service;
+
+import com.example.demo.common.exception.CustomException;
+import com.example.demo.common.exception.ErrorCode;
+import com.example.demo.domain.board.entity.Board;
+import com.example.demo.domain.board.repository.BoardRepository;
+import com.example.demo.domain.card.entity.Card;
+import com.example.demo.domain.card.service.CardService;
+import com.example.demo.domain.column.entity.BoardColumn;
+import com.example.demo.domain.column.repository.ColumnRepository;
+import com.example.demo.domain.comment.dto.CommentRequestDto;
+import com.example.demo.domain.comment.dto.CommentResponseDto;
+import com.example.demo.domain.comment.entity.Comment;
+import com.example.demo.domain.comment.repository.CommentRepository;
+import com.example.demo.domain.user.entity.User;
+import com.example.demo.domain.user.service.UserService;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final ColumnRepository columnRepository;
+    private final CardService cardService;
+    private final UserService userService;
+
+
+    // 댓글 작성 기능
+    public CommentResponseDto createComment(Long cardId, CommentRequestDto requestDto, String username) {
+
+        // 로그인하지 않은 사용자 예외 처리
+        if (username == null) {
+            throw new CustomException(ErrorCode.USER_NOT_LOGGED_IN_TO_CREATE_COMMENT);
+        }
+
+        User user = userService.findUserByUsername(username);
+        Card card = cardService.findById(cardId);
+
+        // 삭제된 카드 예외 처리
+        if (card.isDeleted()) {
+            throw new CustomException(ErrorCode.CANNOT_COMMENT_ON_DELETED_CARD);
+        }
+
+        // 권한 확인
+        if (cardService.hasPermissionForCard(user.getId(), cardId)) {
+            // 권한이 있는 경우에 수행할 작업: 댓글 생성 및 저장
+            Comment comment = new Comment(requestDto.getContent(), card, user);
+            Comment savedComment = commentRepository.save(comment);
+            return convertToResponseDto(savedComment);
+        } else {
+            throw new CustomException(ErrorCode.USER_NOT_MANAGER);
+        }
+    }
+
+
+    // 특정 카드 댓글 조회 기능
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getCommentsByCardId(Long cardId, String username) {
+
+        // 로그인하지 않은 사용자 예외 처리
+        if (username == null) {
+            throw new CustomException(ErrorCode.USER_NOT_LOGGED_IN_TO_VIEW_COMMENTS);
+        }
+
+        User user = userService.findUserByUsername(username);
+        Card card = cardService.findById(cardId);
+
+        // 삭제된 카드 예외 처리
+        if (card.isDeleted()) {
+            throw new CustomException(ErrorCode.CANNOT_VIEW_COMMENTS_OF_DELETED_CARD);
+        }
+
+        // 권한 확인
+        if (cardService.hasPermissionForCard(user.getId(), cardId)) {
+            // 권한이 있는 경우에 수행할 작업: 댓글 조회
+            return commentRepository.findByCardIdOrderByCreatedAtDesc(cardId).stream()
+                    .map(this::convertToResponseDto)
+                    .collect(Collectors.toList());
+        } else {
+            throw new CustomException(ErrorCode.USER_NOT_MANAGER);
+        }
+    }
+
+    // 초대 받은 모든 보드에서 생성된 카드의 댓글 조회
+    @Transactional(readOnly = true)
+    public List<CommentResponseDto> getAllCommentsFromInvitedBoards(String username) {
+        // 로그인하지 않은 사용자 예외 처리
+        if (username == null) {
+            throw new CustomException(ErrorCode.USER_NOT_LOGGED_IN_TO_VIEW_COMMENTS);
+        }
+
+        User user = userService.findUserByUsername(username);
+
+        // 초대받은 모든 보드를 조회
+        List<Board> invitedBoards = boardRepository.findByPermissions_User_Id(user.getId());
+
+        // 각 보드에서 생성된 카드의 댓글을 조회
+        List<CommentResponseDto> allComments = new ArrayList<>();
+        for (Board board : invitedBoards) {
+            List<BoardColumn> columns = columnRepository.findAllByBoardOrdersByOrder(board);
+            for (BoardColumn column : columns) {
+                for (Card card : column.getCards()) {
+                    List<Comment> comments = commentRepository.findByCardIdOrderByCreatedAtDesc(card.getId());
+                    allComments.addAll(comments.stream()
+                            .map(this::convertToResponseDto)
+                            .toList());
+                }
+            }
+        }
+
+        return allComments;
+    }
+
+    // 해당 메소드를 통해 엔티티를 DTO로 변환
+    private CommentResponseDto convertToResponseDto(Comment comment) {
+        return CommentResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .username(comment.getUser().getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/domain/permission/repository/PermissionRepository.java
+++ b/src/main/java/com/example/demo/domain/permission/repository/PermissionRepository.java
@@ -3,8 +3,6 @@ package com.example.demo.domain.permission.repository;
 import com.example.demo.domain.permission.entity.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PermissionRepository extends JpaRepository<Permission, Long> {
     Permission findByUser_IdAndBoard_Id(Long userid, Long boardId);
 }


### PR DESCRIPTION
## 📝작업 내용

- 카드 상세 기능 (댓글 작성, 조회 / 권한에 따라) & 초대받은 모든 보드에서 생성된 카드의 댓글 조회

- 상세 기능 구현에 따른 기존 Card 관련 로직 수정 

- 그 외 필요 없는 import 문, 주석 제거 및 튜터님 피드백 반영으로 기존 API 언더 스코프 개선 

- 상세 설명 주석 추가 및 커밋 상세 기재

<br>


## 🔎 앞으로의 과제

- 정상 작동 확인